### PR TITLE
use APIKEY env var instead of hardcoded key

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -4,6 +4,10 @@ A GraphQL endpoint for the world cup data because why not ?
 
 https://worldcup-graphql.now.sh/
 
+Get your free APIKEY on [football-data](https://api.football-data.org/client/register) and use it as a environmnet variable, if not you will only be able to make 50 requests per day.
+```
+export APIKEY=somekeydata
+```
 ...
 
 ## Authors and license

--- a/utils/axios.js
+++ b/utils/axios.js
@@ -1,6 +1,6 @@
 const axios = require('axios')
 
-const key = 'd1ca7688bf714bc396a7f69913e88292'
+const key = process.env.APIKEY || ""
 
 const get = axios.create({
   baseURL: 'http://api.football-data.org/v1/',


### PR DESCRIPTION
to avoid API usage as this code has the potential to viralize or to be reimplemented in other langs (where devs use to keep details as apikeys), but as original API stated, you can use it without any api key at all, restricting to 50 requests per day.