### PR TITLE
Cache API data

### DIFF
--- a/src/resolvers.js
+++ b/src/resolvers.js
@@ -7,9 +7,9 @@ const getPlayers = async teamID => {
   if (cache.contains(cacheKey)) {
     return cache.get(cacheKey)
   } else {
-    const players = await network.getPlayers(teamID)
-    cache.set(cacheKey, players)
-    return players
+    const response = await network.getPlayers(teamID)
+    cache.set(cacheKey, response.data.players)
+    return response.data.players
   }
 }
 
@@ -19,9 +19,9 @@ const getGames = async teamID => {
   if (cache.contains(cacheKey)) {
     return cache.get(cacheKey)
   } else {
-    const games = await network.getGames(teamID)
-    cache.set(cacheKey, games)
-    return games
+    const response = await network.getGames(teamID)
+    cache.set(cacheKey, response.data.games)
+    return response.data.games
   }
 }
 
@@ -31,28 +31,20 @@ const getTeams = async () => {
   if (cache.contains(cacheKey)) {
     return cache.get(cacheKey)
   } else {
-    const teams = await network.getTeams()
-    cache.set(cacheKey, teams)
-    return teams
+    const response = await network.getTeams()
+    cache.set(cacheKey, response.data.teams)
+    return response.data.teams
   }
 }
 
 module.exports = {
   Query: {
-    players: async (_, { teamID }) => {
-      const players = await getPlayers(teamID)
-
-      return players.data.players
-    },
-    games: async (_, { teamID }) => {
-      const fixtures = await getGames(teamID)
-
-      return fixtures.data.fixtures
-    },
+    players: (_, { teamID }) => getPlayers(teamID),
+    games: (_, { teamID }) => getGames(teamID),
     teams: async () => {
       const teams = await getTeams()
 
-      return teams.data.teams.map(async t => {
+      return teams.map(async t => {
         try {
           const id = t._links.self.href.split('/teams/')[1]
           const players = await getPlayers(id)

--- a/src/resolvers.js
+++ b/src/resolvers.js
@@ -20,8 +20,8 @@ const getGames = async teamID => {
     return cache.get(cacheKey)
   } else {
     const response = await network.getGames(teamID)
-    cache.set(cacheKey, response.data.games)
-    return response.data.games
+    cache.set(cacheKey, response.data.fixtures)
+    return response.data.fixtures
   }
 }
 

--- a/src/resolvers.js
+++ b/src/resolvers.js
@@ -2,6 +2,10 @@ const network = require('../utils/requests')
 const cache = require('../utils/cache')
 const { pipe } = require('../utils/functional')
 
+/*
+ *  Fetches players from cache if resource exists,
+ *  otherwise from network 
+ */
 const getPlayers = async teamID => {
   const cacheKey = `players-${teamID}`
 
@@ -14,6 +18,10 @@ const getPlayers = async teamID => {
   }
 }
 
+/*
+ *  Fetches games from cache if resource exists,
+ *  otherwise from network 
+ */
 const getGames = async teamID => {
   const cacheKey = `games-${teamID}`
 
@@ -26,6 +34,10 @@ const getGames = async teamID => {
   }
 }
 
+/*
+ *  Fetches teams from cache if resource exists,
+ *  otherwise from network 
+ */
 const getTeams = async () => {
   const cacheKey = 'teams'
 
@@ -38,9 +50,11 @@ const getTeams = async () => {
   }
 }
 
+/* Filters teams by name */
 const filterTeams = name => teams =>
   teams.filter(team => (name ? team.name === name : true))
 
+/* Maps teams to a schema-compliant structure */
 const transformTeams = teams =>
   teams.map(team => ({
     ...team,

--- a/src/resolvers.js
+++ b/src/resolvers.js
@@ -44,20 +44,11 @@ module.exports = {
     teams: async () => {
       const teams = await getTeams()
 
-      return teams.map(async t => {
-        try {
-          const id = t._links.self.href.split('/teams/')[1]
-          const players = await getPlayers(id)
-          const fixtures = await getGames(id)
-          t.id = id
-          t.flag = t.crestUrl
-          t.players = players.data.players
-          t.games = fixtures.data.fixtures
-        } catch (e) {
-          console.log(e)
-        }
-        return t
-      })
+      return teams.map(team => ({
+        ...team,
+        id: team._links.self.href.split('/teams/')[1],
+        flag: team.crestUrl
+      }))
     }
   }
 }

--- a/src/resolvers.js
+++ b/src/resolvers.js
@@ -1,4 +1,41 @@
-const { getPlayers, getGames, getTeams } = require('../utils/requests')
+const network = require('../utils/requests')
+const cache = require('../utils/cache')
+
+const getPlayers = async teamID => {
+  const cacheKey = `players-${teamID}`
+
+  if (cache.contains(cacheKey)) {
+    return cache.get(cacheKey)
+  } else {
+    const players = await network.getPlayers(teamID)
+    cache.set(cacheKey, players)
+    return players
+  }
+}
+
+const getGames = async teamID => {
+  const cacheKey = `games-${teamID}`
+
+  if (cache.contains(cacheKey)) {
+    return cache.get(cacheKey)
+  } else {
+    const games = await network.getGames(teamID)
+    cache.set(cacheKey, games)
+    return games
+  }
+}
+
+const getTeams = async () => {
+  const cacheKey = 'teams'
+
+  if (cache.contains(cacheKey)) {
+    return cache.get(cacheKey)
+  } else {
+    const teams = await network.getTeams()
+    cache.set(cacheKey, teams)
+    return teams
+  }
+}
 
 module.exports = {
   Query: {
@@ -13,7 +50,8 @@ module.exports = {
       return fixtures.data.fixtures
     },
     teams: async () => {
-      const teams = await await getTeams()
+      const teams = await getTeams()
+
       return teams.data.teams.map(async t => {
         try {
           const id = t._links.self.href.split('/teams/')[1]

--- a/src/schema.js
+++ b/src/schema.js
@@ -50,5 +50,7 @@ module.exports = `
     shortName: String
     squadMarketValue: String
     flag: String
+    players: [Player] @deprecated
+    games: [Fixture] @deprecated
   }
 `

--- a/src/schema.js
+++ b/src/schema.js
@@ -2,8 +2,8 @@ module.exports = `
   type Query {
     info: Info
     teams(name: String): [Team]!
-    players(teamID: Int): [Player]!
-    games(teamID: Int): [Fixture]!
+    players(teamID: Int!): [Player]!
+    games(teamID: Int!): [Fixture]!
   }
 
 

--- a/src/schema.js
+++ b/src/schema.js
@@ -50,7 +50,5 @@ module.exports = `
     shortName: String
     squadMarketValue: String
     flag: String
-    players: [Player],
-    games: [Fixture]
   }
 `

--- a/utils/cache.js
+++ b/utils/cache.js
@@ -1,0 +1,27 @@
+const cache = {}
+
+const contains = key => cache[key] !== undefined
+
+const invalidate = key => {
+  cache[key] = undefined
+}
+
+const get = key => cache[key]
+
+const set = (key, value, options) => {
+  let effectiveOptions = { maxAge: 1000 * 60 }
+
+  if (options !== undefined) {
+    effectiveOptions = options
+  }
+
+  cache[key] = value
+  setTimeout(() => invalidate(key), effectiveOptions.maxAge)
+}
+
+module.exports = {
+  contains,
+  invalidate,
+  get,
+  set
+}

--- a/utils/cache.js
+++ b/utils/cache.js
@@ -1,13 +1,17 @@
 const cache = {}
 
-const contains = key => cache[key] !== undefined
-
+/* Unsets cache entry */
 const invalidate = key => {
   cache[key] = undefined
 }
 
+/* Checks if entry exists in cache */
+const contains = key => cache[key] !== undefined
+
+/* Gets cache entry */
 const get = key => cache[key]
 
+/* Sets cache entry */
 const set = (key, value, options) => {
   let effectiveOptions = { maxAge: 1000 * 60 }
 
@@ -21,7 +25,6 @@ const set = (key, value, options) => {
 
 module.exports = {
   contains,
-  invalidate,
   get,
   set
 }

--- a/utils/functional.js
+++ b/utils/functional.js
@@ -1,0 +1,6 @@
+const pipe = (...funcs) => value =>
+  funcs.reduce((acc, func) => func(acc), value)
+
+module.exports = {
+  pipe
+}

--- a/utils/functional.js
+++ b/utils/functional.js
@@ -1,3 +1,4 @@
+/* Performs left-to-right function composition */
 const pipe = (...funcs) => value =>
   funcs.reduce((acc, func) => func(acc), value)
 


### PR DESCRIPTION
- Caches [football-data.org](https://www.football-data.org/)'s data temporarily (defaults to 1 minute) to avoid `429 Too Many Requests` HTTP errors
- Deprecates nesting `players` & `games` under `teams` to avoid bombarding [football-data.org](https://www.football-data.org/) with 2 requests per retrieved team, which results in `429 Too Many Requests` HTTP errors
- Enforces passing `teamID` to the `players` & `games` queries
- Enables filtering `teams` query results by `name`