### PR TITLE
add resolver to get all fixtures in tournament  and add "rounds" text…

### DIFF
--- a/src/rounds.js
+++ b/src/rounds.js
@@ -1,0 +1,12 @@
+/* Map API's 'matchday' to a string representing current round of competition */
+
+module.exports = {
+  1: 'Group stage: match 1',
+  2: 'Group stage: match 2',
+  3: 'Group stage: match 3',
+  4: 'Round of 16',
+  5: 'Quarter finals',
+  6: 'Semi finals',
+  7: 'Third place',
+  8: 'Final'
+}

--- a/src/schema.js
+++ b/src/schema.js
@@ -4,6 +4,7 @@ module.exports = `
     teams(name: String): [Team]!
     players(teamID: Int!): [Player]!
     games(teamID: Int!): [Fixture]!
+    fixtures: [Fixture]!
   }
 
 
@@ -41,6 +42,7 @@ module.exports = `
     awayTeamName: String,
     result: Result
     odds: String
+    round: String
   }
 
   type Team {

--- a/utils/requests.js
+++ b/utils/requests.js
@@ -2,4 +2,5 @@ const get = require('./axios')
 
 module.exports.getPlayers = (teamID) => get(`teams/${teamID}/players`)
 module.exports.getGames = (teamID) => get(`teams/${teamID}/fixtures`)
+module.exports.getFixtures = () => get('competitions/467/fixtures')
 module.exports.getTeams = () => get('competitions/467/teams')


### PR DESCRIPTION
Hi @SaraVieira 

Was just using your project to list out all the upcoming fixtures in the World Cup so made some changes for that. Also adds round names (e.g. "Semi-finals") to the fixtures as I couldn't see this in the football-data API.

If you think the above change would be useful for others feel free to merge, thanks for setting up the project!

Cheers
Jon